### PR TITLE
Automatic canvas adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,7 @@ you may follow these helpful instructions!
 
     git clone https://github.com/weebygames/phaser-template
 
-2. Place your game code into the src/game.js file. Note that the intialization of
-   Phaser.Game is done inside the `exports = function(width, height, canvas) { ... }`.
-   As of right now, this is necessary. It is also necessary to call `game.setCanvas(canvas)`.
-   Note further that the width and height passed into this function are the width
-   and height are that of the device.
+2. Place your game code into the src/game.js file!
 
 Additional Notes
 ----------------

--- a/src/Application.js
+++ b/src/Application.js
@@ -157,7 +157,7 @@ exports = Class(GC.Application, function () {
             image: image,
             width: rootView.style.width,
             height: rootView.style.height,
-            parent: this
+            parent: this.getRootView()
         });
         iv.render = function(ctx) {
             image.render(ctx, 0, 0, width, height, 0, 0, this.style.width, this.style.height);

--- a/src/Application.js
+++ b/src/Application.js
@@ -91,6 +91,9 @@ Phaser.Game = function() {
     addEventListenerAPI(GC.app.canvas);
     GC.app.spoofMouseEvents(GC.app, GC.app.canvas);
 
+    GC.app.canvas.style.width = '' + device.screen.width + 'px';
+    GC.app.canvas.style.height = '' + device.screen.height + 'px';
+
     game.setCanvas(GC.app.canvas);
     return game;
 };
@@ -104,6 +107,8 @@ exports = Class(GC.Application, function () {
 
     this.initUI = function () {
         this._gameLoaded = false;
+        this.scalex = 1;
+        this.scaley = 1;
 
         // Leave the clearing to pixi
         this.engine.updateOpts({
@@ -119,12 +124,12 @@ exports = Class(GC.Application, function () {
     };
 
     this.spoofMouseEvents = function(view, canvas) {
-        function makeMouseEvent(evt) {
+        var makeMouseEvent = function (evt) {
             evt.preventDefault = function() {};
             evt.changedTouches = [];
-            evt.pageX = evt.screenX = evt.clientX = evt.pt[1].x;
-            evt.pageY = evt.screenY = evt.clientY = evt.pt[1].y;
-        }
+            evt.pageX = evt.screenX = evt.clientX = evt.pt[1].x * this.scalex;
+            evt.pageY = evt.screenY = evt.clientY = evt.pt[1].y * this.scaley;
+        }.bind(this);
 
         // Spoof mouse events with devkit input functions
         view.onInputSelect = function(evt, pt) {
@@ -186,5 +191,24 @@ exports = Class(GC.Application, function () {
     this.getRootView = function() {
         return config.useWeeby ? weeby.getGameView() : this.view;
     };
+
+    this.tick = function(dt) {
+        if (this.canvas) {
+            var scr = device.screen;
+            var canvas = this.canvas;
+            var style = canvas.style;
+
+            var wpx = scr.width + 'px';
+            var hpx = scr.height + 'px';
+
+            if (wpx !== style.width || hpx !== style.height) {
+                this.scalex = canvas.width / scr.width;
+                this.scaley = canvas.height / scr.height;
+
+                style.width  = wpx;
+                style.height = hpx;
+            }
+        }
+    }
 });
 

--- a/src/Application.js
+++ b/src/Application.js
@@ -72,6 +72,7 @@ var construct = function(constructor, args) {
 // Hook Phaser.Game
 var phaser_game = Phaser.Game;
 Phaser.Game = function() {
+    var app = GC.app;
     var width  = arguments[0] || 800;
     var height = arguments[1] || 600;
 
@@ -81,20 +82,16 @@ Phaser.Game = function() {
     var game = construct(phaser_game, arguments);
 
     // Get the main canvas and add event listener to it
-    if (device.isMobileNative) {
-      GC.app.canvas = GC.app.engine.getCanvas();
-    } else {
-      var canvasView = GC.app.makeCanvasBackedView(width, height);
-      GC.app.canvas = canvasView.getCanvas();
-    }
+    var canvasView = GC.app.makeCanvasBackedView(width, height);
+    app.canvas = canvasView.getCanvas();
 
-    addEventListenerAPI(GC.app.canvas);
-    GC.app.spoofMouseEvents(GC.app, GC.app.canvas);
+    addEventListenerAPI(app.canvas);
+    app.spoofMouseEvents(app, app.canvas);
 
-    GC.app.canvas.style.width = '' + device.screen.width + 'px';
-    GC.app.canvas.style.height = '' + device.screen.height + 'px';
+    app.game_width  = width;
+    app.game_height = height;
 
-    game.setCanvas(GC.app.canvas);
+    game.setCanvas(app.canvas);
     return game;
 };
 
@@ -135,10 +132,13 @@ exports = Class(GC.Application, function () {
         view.onInputSelect = function(evt, pt) {
             makeMouseEvent(evt);
             canvas.publishEvent('mouseup', evt);
+            canvas.publishEvent('touchend', evt);
+            canvas.publishEvent('click', evt);
         };
         view.onInputStart = function(evt, pt) {
             makeMouseEvent(evt);
             canvas.publishEvent('mousedown', evt);
+            canvas.publishEvent('touchstart', evt);
         };
         view.onInputMove = function(evt) {
             evt.pt = evt.point; // FIXME this seems like a inconsistency in devkit...
@@ -156,7 +156,8 @@ exports = Class(GC.Application, function () {
         var iv = new View({
             image: image,
             width: rootView.style.width,
-            height: rootView.style.height
+            height: rootView.style.height,
+            parent: this
         });
         iv.render = function(ctx) {
             image.render(ctx, 0, 0, width, height, 0, 0, this.style.width, this.style.height);
@@ -193,20 +194,22 @@ exports = Class(GC.Application, function () {
     };
 
     this.tick = function(dt) {
+        // TODO this should probably be in an "on resize" function
         if (this.canvas) {
             var scr = device.screen;
-            var canvas = this.canvas;
-            var style = canvas.style;
 
-            var wpx = scr.width + 'px';
-            var hpx = scr.height + 'px';
+            if (scr.width != this.last_width || scr.height != this.last_height) {
+                this.last_width = scr.width;
+                this.last_height = scr.height;
 
-            if (wpx !== style.width || hpx !== style.height) {
-                this.scalex = canvas.width / scr.width;
-                this.scaley = canvas.height / scr.height;
+                if (scr.width > scr.height) {
+                    this.engine.scaleUI(scr.height, scr.width);
+                } else {
+                    this.engine.scaleUI(scr.width, scr.height);
+                }
 
-                style.width  = wpx;
-                style.height = hpx;
+                this.scalex = this.game_width / scr.width;
+                this.scaley = this.game_height / scr.height;
             }
         }
     }

--- a/src/phaser.js
+++ b/src/phaser.js
@@ -7,7 +7,7 @@
 *
 * Phaser - http://phaser.io
 *
-* v2.2.2 "Alkindar" - Built: Tue Feb 17 2015 01:15:24
+* v2.2.2 "Alkindar" - Built: Tue Feb 17 2015 20:49:07
 *
 * By Richard Davey http://www.photonstorm.com @photonstorm
 *
@@ -3149,6 +3149,8 @@ PIXI.Text.prototype.determineFontProperties = function(fontStyle)
 
     if(!properties)
     {
+        properties = {};
+
         if (PIXI.DEVKIT_NATIVE)
         {
             var Font = jsio('import ui.resource.Font');
@@ -3160,8 +3162,6 @@ PIXI.Text.prototype.determineFontProperties = function(fontStyle)
         }
         else
         {
-            properties = {};
-
             var canvas = PIXI.Text.fontPropertiesCanvas;
             var context = PIXI.Text.fontPropertiesContext;
 
@@ -12357,7 +12357,7 @@ PIXI.AbstractFilter.prototype.apply = function(frameBuffer)
 *
 * Phaser - http://phaser.io
 *
-* v2.2.2 "Alkindar" - Built: Tue Feb 17 2015 01:15:24
+* v2.2.2 "Alkindar" - Built: Tue Feb 17 2015 20:49:07
 *
 * By Richard Davey http://www.photonstorm.com @photonstorm
 *


### PR DESCRIPTION
Now a phaser game can be dropped in just by adding its code to the game.js file. The size of the canvas is sized as the game directs but scales to the device size by default. It would be idea to have this be a more customizable feature, i.e. expose the device information and device rotate events to phaser games in a reasonable manner.
